### PR TITLE
[docs] target stable-1.1 branch in quick start doc

### DIFF
--- a/docs/introduction/quick-start.rst
+++ b/docs/introduction/quick-start.rst
@@ -60,7 +60,7 @@ support, based on Debian Stretch:
 
 .. code-block:: console
 
-   git clone https://github.com/debops/debops ; cd debops
+   git clone -b stable-1.1 https://github.com/debops/debops ; cd debops
    vagrant up && vagrant ssh
 
 The configuration relies heavily on your Vagrant environment. Having a real


### PR DESCRIPTION
changed the git clone directive within vagrant quickstart -- now it target's stable-1.1 branch instead of master.

so that new users will have a stable experience.